### PR TITLE
Declare TZ_CORRECT when using manually-selected timezone

### DIFF
--- a/.scripts/tzSelectionMenu.sh
+++ b/.scripts/tzSelectionMenu.sh
@@ -76,6 +76,7 @@ tzSelectionMenu() {
     else
         selected="/usr/share/zoneinfo/$region/$tz"
         selected_short="$region/$tz"
+        TZ_CORRECT="N"
     fi
 }
 


### PR DESCRIPTION
Could also be handled in step_timezone.sh by checking for whether TZ_CORRECT is declared before checking contents, but this is what I tested :)